### PR TITLE
change environment on release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   release:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     name: Publish and Release
     steps:
       - name: Checkout code


### PR DESCRIPTION
### やったこと
* releaseジョブが失敗する問題が発生したため、一旦実行環境をubuntuに変更してみた
  * Windows環境だとnpm publish時に`spawn EINVAL` になるという[事例](https://github.com/microsoft/vscode-vsce/issues/969)があったので、Ubuntu環境で一旦単めしてみる
    * 事例1:  
  * この変更でも状況が変わらない場合は、https://github.com/akashic-games/action-release で細かくログを出力する対応を行う予定